### PR TITLE
fix: extend SimpleConfiguration instead of Configuration

### DIFF
--- a/static/adapter.dart.tmpl
+++ b/static/adapter.dart.tmpl
@@ -1,7 +1,7 @@
 /*%ADAPTER_IMPORTS%*/
 /*%TEST_IMPORTS%*/
 
-class AdapterConfigutation extends unittest.Configuration {
+class AdapterConfiguration extends unittest.SimpleConfiguration {
   bool get autoStart => false;
 
   void onDone(success) {
@@ -59,7 +59,7 @@ class AdapterConfigutation extends unittest.Configuration {
 }
 
 main() {
-  unittest.unittestConfiguration = new AdapterConfigutation();
+  unittest.unittestConfiguration = new AdapterConfiguration();
 
 /*%TEST_MAIN_CALLS%*/
 


### PR DESCRIPTION
In response to the [breaking change announcement](https://groups.google.com/a/dartlang.org/forum/#!topic/announce/k_UsTYoto3M) of 19 Aug 2013.
