### PR TITLE
Converting from package:js to dart:js

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ and you'll need the following dependencies in your pubspec.yaml
 
     unittest: any
     browser: any
-    js: any
 
 The following is an example of karma config.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ var initDartUnittest = function(emitter, /* config.files */ files, /* config.bas
 
   var adapterImports = {
     unittest: 'package:unittest/unittest.dart',
-    js: 'package:js/js.dart'
+    js: 'dart:js'
   };
 
   if (customImports) {

--- a/static/adapter.dart.tmpl
+++ b/static/adapter.dart.tmpl
@@ -9,7 +9,7 @@ class AdapterConfiguration extends unittest.SimpleConfiguration {
     try {
       super.onDone(success);
     } catch(e) {};
-    js.context.__karma__.complete();
+    js.context['__karma__'].callMethod('complete');
   }
 
   void onTestStart(unittest.TestCase testCase) {
@@ -25,29 +25,29 @@ class AdapterConfiguration extends unittest.SimpleConfiguration {
       logData.add(testCase.message);
       logData.add(testCase.stackTrace.toString());
     }
-    js.context.__karma__.result(
-      js.map({
+    js.context['__karma__'].callMethod('result',
+      [new js.JsObject.jsify({
         'id': testCase.id,
         'description': description,
         'success': testCase.result == unittest.PASS,
         'suite': suites,
         'skipped': !testCase.enabled,
-        'log': js.array(logData),
+        'log': logData,
         'time': testCase.runningTime.inMilliseconds
-      })
+      })]
     );
   }
 
   void onLogMessage(unittest.TestCase testCase, String message) {
-    js.context.__karma__.info(js.map({
+    js.context['__karma__'].callMethod('info', [new js.JsObject.jsify({
       'dump': message
-    }));
+    })]);
   }
 
   void onSummary(int passed, int failed, int errors,
       List<unittest.TestCase> results, String uncaughtError) {
     if (uncaughtError != null) {
-      js.context.__karma__.error(uncaughtError);
+      js.context['__karma__'].callMethod('error', [uncaughtError]);
     }
     // it's OK to print the default summary into the console
     super.onSummary(passed, failed, errors, results, uncaughtError);
@@ -62,8 +62,9 @@ main() {
 
 /*%TEST_MAIN_CALLS%*/
 
-  js.context.__karma__.start = () {};
-  js.context.__karma__.info(js.map({'total': unittest.testCases.length}));
+  js.context['__karma__']['start'] = () {};
+  js.context['__karma__'].callMethod('info', [
+    new js.JsObject.jsify({'total': unittest.testCases.length})]);
   unittest.runTests();
 }
 


### PR DESCRIPTION
package:js adds some syntactical sugar around dart:js but introduces some significant dart2js compilation sizes without aggressive use of MirrorsUsed. In general for packages we'd like to only rely on dart:js. This has the added benefit of removing a dart dependency that users of this package will need.
