### PR TITLE
chore(package.json): require newer dart2jaas

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "karma": ">=0.10"
   },
   "dependencies": {
-    "dart2jsaas": "~0.0.1"
+    "dart2jsaas": "~0.0.16"
   },
   "devDependencies": {
     "grunt-npm": "~0.0.2",


### PR DESCRIPTION
This helps with caching dart2jaas output.

Ref: https://github.com/jbdeboer/dart2jsaas/commit/7e306509e47f8cc8ec9e431527fd1ccb5863576f
